### PR TITLE
Use raw instead of version for fullVersion

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -15,7 +15,7 @@ class SemanticVersion {
 
 function createSemanticVersion(parsedSemver) {
     return new SemanticVersion(
-        parsedSemver.version,
+        parsedSemver.raw,
         parsedSemver.major, parsedSemver.minor, parsedSemver.patch,
         parsedSemver.prerelease.join(SEMVER_PRERELEASE_BUILD_SEPARATOR),
         parsedSemver.build.join(SEMVER_PRERELEASE_BUILD_SEPARATOR)


### PR DESCRIPTION
A parse of `'3.4.5-alpha+1.2'` does not result in the semver objects property of version to the same value.
The raw value is stored in `raw`.
This fixes the missing `+1.2` in the fullVersion.

Fixes #14